### PR TITLE
Fix meta(absinthe_telemetry: true/false)

### DIFF
--- a/lib/absinthe/schema/notation.ex
+++ b/lib/absinthe/schema/notation.ex
@@ -536,7 +536,7 @@ defmodule Absinthe.Schema.Notation do
     |> recordable!(:resolve, @placement[:resolve])
 
     quote do
-      meta :absinthe_telemetry, true
+      meta :absinthe_telemetry_implicit, true
       middleware Absinthe.Resolution, unquote(func_ast)
     end
   end
@@ -1679,15 +1679,24 @@ defmodule Absinthe.Schema.Notation do
     [Absinthe.Middleware.PassParent]
   end
 
-  def __ensure_middleware__([], %{identifier: identifier}, _) do
-    [{Absinthe.Middleware.MapGet, identifier}]
+  def __ensure_middleware__([], %{identifier: identifier} = field, object) do
+    middleware = [{Absinthe.Middleware.MapGet, identifier}]
+    __ensure_middleware__(middleware, field, object)
   end
 
   def __ensure_middleware__(middleware, field, _object) do
-    if Absinthe.Type.meta(field, :absinthe_telemetry) do
+    if add_telemetry_middleware?(field) do
       [{Absinthe.Middleware.Telemetry, []} | middleware]
     else
       middleware
+    end
+  end
+
+  defp add_telemetry_middleware?(field) do
+    case Absinthe.Type.meta(field, :absinthe_telemetry) do
+      true -> true
+      false -> false
+      nil -> Absinthe.Type.meta(field, :absinthe_telemetry_implicit)
     end
   end
 


### PR DESCRIPTION
### Fixes

- Defining a resolver now sets `:absinthe_telemetry_implicit` in a field's meta so that a user-provided `:absinthe_telemetry` value is not overridden / doesn't conflict
- Additionally, setting `absinthe_telemetry: true` on a field without a resolver now adds the telemetry middleware.

---

### Issue

Ran into an exception when setting `meta(abinsthe_telemetry: false)` on a field that defined a resolver.  i.e.

```elixir
field :example, :string do
  meta(abinsthe_telemetry: false)
  resolve(fn _, _, _ -> {:ok, "hello world"} end)
end
```

would raise an error when compiling:

```
== Compilation error in file test/absinthe/schema_test.exs ==
** (FunctionClauseError) no function clause matching in Keyword.merge/3

    The following arguments were given to Keyword.merge/3:

        # 1
        false

        # 2
        true

        # 3
        #Function<12.43655748/3 in Absinthe.Blueprint.Schema.update_private/2>

    Attempted function clauses (showing 1 out of 1):

        def merge(keywords1, keywords2, fun) when is_list(keywords1) and is_list(keywords2) and is_function(fun, 3)

    (elixir) lib/keyword.ex:763: Keyword.merge/3
    (elixir) lib/keyword.ex:776: Keyword.do_merge/6
    (elixir) lib/keyword.ex:776: Keyword.do_merge/6
    (elixir) lib/map.ex:752: Map.update!/3
    (absinthe) lib/absinthe/blueprint/schema.ex:143: Absinthe.Blueprint.Schema.build_types/3
    (absinthe) expanding macro: Absinthe.Schema.Notation.__before_compile__/1
    test/absinthe/schema_test.exs:436: Absinthe.SchemaTest.TelemetrySchema (module)
    (elixir) lib/code.ex:767: Code.require_file/2
    (elixir) lib/kernel/parallel_compiler.ex:211: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/6
```
